### PR TITLE
Fix incorrect path to Wholebody models + update README

### DIFF
--- a/DWPose/dwpose_utils/wholebody.py
+++ b/DWPose/dwpose_utils/wholebody.py
@@ -11,8 +11,8 @@ class Wholebody:
         # device = 'cuda'
         providers = ['CPUExecutionProvider'
                  ] if device == 'cpu' else ['CUDAExecutionProvider']
-        onnx_det = 'path/checkpoints/DWPose/yolox_l.onnx'
-        onnx_pose = 'path/checkpoints/DWPose/dw-ll_ucoco_384.onnx'
+        onnx_det = 'checkpoints/DWPose/yolox_l.onnx'
+        onnx_pose = 'checkpoints/DWPose/dw-ll_ucoco_384.onnx'
 
         self.session_det = ort.InferenceSession(path_or_bytes=onnx_det, providers=providers)
         self.session_pose = ort.InferenceSession(path_or_bytes=onnx_pose, providers=providers)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ onnx_pose = 'path/checkpoints/DWPose/dw-ll_ucoco_384.onnx'
 ```
 Given the target image folder containing multiple .png files, you can use the following command to obtain the corresponding human skeleton images:
 ```
-python skeleton_extraction.py --target_image_folder_path="path/test/target_images" --ref_image_path="path/test/reference.png" --poses_folder_path="path/test/poses"
+python DWPose/skeleton_extraction.py --target_image_folder_path="path/test/target_images" --ref_image_path="path/test/reference.png" --poses_folder_path="path/test/poses"
 ```
 It is worth noting that the .png files in the target image folder are named in the format `frame_i.png`, such as `frame_0.png`, `frame_1.png`, and so on. 
 `--ref_image_path` refers to the path of the given reference image. The obtained human skeleton images are saved in `path/test/poses`. It is particularly significant that the target skeleton images should be aligned with the reference image regarding the body shape.


### PR DESCRIPTION
## Background
When trying this out I encountered the following error:
```
Traceback (most recent call last):
  File "/home/user/StableAnimator/DWPose/skeleton_extraction.py", line 6, in <module>
    from dwpose_utils.dwpose_detector import dwpose_detector_aligned
  File "/home/user/StableAnimator/DWPose/dwpose_utils/dwpose_detector.py", line 57, in <module>
    dwpose_detector_aligned = DWposeDetectorAligned(device=device)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/StableAnimator/DWPose/dwpose_utils/dwpose_detector.py", line 13, in __init__
    self.pose_estimation = Wholebody()
                           ^^^^^^^^^^^
  File "/home/user/StableAnimator/DWPose/dwpose_utils/wholebody.py", line 17, in __init__
    self.session_det = ort.InferenceSession(path_or_bytes=onnx_det, providers=providers)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/stableanimator/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 465, in __init__
    self._create_inference_session(providers, provider_options, disabled_optimizers)
  File "/home/user/mambaforge/envs/stableanimator/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 526, in _create_inference_session
    sess = C.InferenceSession(session_options, self._model_path, True, self._read_config_from_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
onnxruntime.capi.onnxruntime_pybind11_state.NoSuchFile: [ONNXRuntimeError] : 3 : NO_SUCHFILE : Load model from path/checkpoints/DWPose/yolox_l.onnx failed:Load model path/checkpoints/DWPose/yolox_l.onnx failed. File doesn't exist
```

It was because the path for the Wholebody models had a `path/` prefix. I removed this path and ran it from the root project dir and the command worked. Because of that, I also updated the README to show that you should run it from the root project dir.