### PR TITLE
Changing absolute local imports to relative paths

### DIFF
--- a/animation/modules/unet.py
+++ b/animation/modules/unet.py
@@ -10,7 +10,7 @@ from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_utils import ModelMixin
 from diffusers.utils import BaseOutput, logging
 
-from animation.modules.unet_3d_blocks import get_down_block, UNetMidBlockSpatioTemporal, get_up_block
+from .unet_3d_blocks import get_down_block, UNetMidBlockSpatioTemporal, get_up_block
 # from diffusers.models.unets.unet_3d_blocks import get_down_block, get_up_block, UNetMidBlockSpatioTemporal
 
 

--- a/animation/modules/unet_3d_blocks.py
+++ b/animation/modules/unet_3d_blocks.py
@@ -32,7 +32,7 @@ from diffusers.models.transformers.transformer_2d import Transformer2DModel
 #     TransformerSpatioTemporalModel,
 #     TransformerTemporalModel,
 # )
-from animation.modules.transformer_temporal import TransformerTemporalModel, TransformerSpatioTemporalModel
+from .transformer_temporal import TransformerTemporalModel, TransformerSpatioTemporalModel
 
 from diffusers.models.unets.unet_motion_model import (
     CrossAttnDownBlockMotion,

--- a/animation/pipelines/inference_pipeline_animation.py
+++ b/animation/pipelines/inference_pipeline_animation.py
@@ -14,7 +14,7 @@ from diffusers.pipelines.stable_video_diffusion.pipeline_stable_video_diffusion 
 from diffusers.utils import BaseOutput, logging
 from diffusers.utils.torch_utils import is_compiled_module, randn_tensor
 
-from animation.modules.attention_processor import AnimationAttnProcessor, AnimationIDAttnProcessor
+from ..modules.attention_processor import AnimationAttnProcessor, AnimationIDAttnProcessor
 from einops import rearrange
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name


### PR DESCRIPTION
When using StableAnimator as a library, we cannot assume that it is in python path. So I suggest fixing some imports to use relative paths.